### PR TITLE
Overhaul UI to dark theme and add editor settings integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## About
+
+Parsenip is an interactive JavaScript interpreter and AST visualizer that runs in the browser. Source code flows through:
+
+```
+Source → Lexer → Tokens → Parser → AST → Evaluator → Result
+```
+
+The UI is a split-screen: a Monaco-based code editor on the left, and a tabbed results panel on the right showing either the token list or the AST.
+
+## Commands
+
+```bash
+npm run dev       # Start Vite dev server at http://localhost:5000
+npm run build     # tsc + Vite production build
+npm run lint      # ESLint (zero warnings allowed)
+npm run test      # Run Jest unit tests
+npm run repl      # Start CLI REPL (uses tsx)
+npm run repl <filename>  # Execute a file via the CLI
+```
+
+Run a single test file:
+```bash
+npx jest src/interpreter/lexer.test.ts
+```
+
+## Architecture
+
+### Interpreter (`src/interpreter/`)
+
+The core language engine — pure TypeScript with no UI dependencies.
+
+- **`token.ts`** — `TokenType` enum, `Token` interface, `Position` type (`{ start, end }` as character offsets into the source string), and `lookupIdentifierType` for keyword detection.
+- **`lexer.ts`** — `Lexer` class and `lex()` convenience function. Each token carries a `Position` with absolute character offsets used for editor highlighting.
+- **`ast.ts`** — All AST node type definitions. Every node extends a base with `type`, `start`, and `end` (character offsets).
+- **`parser.ts`** — Pratt (top-down operator precedence) parser. Uses `prefixParseFns` and `infixParseFns` maps keyed by `TokenType`. Supports `testMode` flag to suppress errors in tests.
+- **`evaluator.ts`** — Tree-walking evaluator. Dispatches on `node.type` via a switch statement.
+- **`object.ts`** — Runtime value types returned by the evaluator.
+- **`environment.ts`** — Lexical scoping for variable bindings.
+
+### UI (`src/`)
+
+- **`App.tsx`** — Root component. Calls `lex(input)` directly for the token panel; passes `input` to `ParserPanel` for parsing and AST display. Manages code highlighting via `highlightCode(start, end)` from `useEditor`.
+- **`features/textEditor/useEditor.tsx`** — Monaco editor integration. Tracks cursor position as an absolute character offset (via `getOffsetAt`). Exposes `highlightCode(start, end)` which converts offsets back to line/column for Monaco decorations. Persists editor content to `localStorage`.
+- **`features/resultsPanel/ResultsPanel.tsx`** — Tabbed panel container with "tokens" and "parser" tabs (defaults to "parser").
+- **`features/resultsPanel/TokenCard.tsx`** — Renders a single token with type and position.
+- **`features/resultsPanel/ParserPanel.tsx`** — Parses input and renders the root `ASTNode`.
+- **`features/resultsPanel/ASTNode.tsx`** — Recursive component that renders any AST node. Auto-expands when the cursor is over the node's range, and supports manual expand/collapse. Highlights the editor range on hover.
+- **`components/Expander.tsx`** — Collapsible container used by `ASTNode`.
+
+### Key Data Flow
+
+1. User types in Monaco editor → `useEditor` captures input and cursor position (as absolute offsets).
+2. `App.tsx` calls `lex(input)` → renders `TokenCard` list.
+3. `App.tsx` passes `input` to `ParserPanel` → `Parser` builds AST → `ASTNode` renders recursively.
+4. Hovering a `TokenCard` or `ASTNode` calls `highlightCode(start, end)` → Monaco applies a `highlighted-code` inline decoration.
+5. `cursorPosition` (absolute offset) flows into every `ASTNode`; nodes auto-expand when cursor is within their `start`–`end` range.
+
+### Tests
+
+Tests live alongside interpreter source files (`*.test.ts`). They use Jest + `ts-jest`. The `Parser` accepts `testMode: true` to suppress console errors.

--- a/src/App.css
+++ b/src/App.css
@@ -22,3 +22,12 @@
 .highlighted-code {
   background-color: #f5f5d6;
 }
+
+.tokenPanel {
+  background-color: #fff;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  row-gap: 10px;
+  padding: 15px;
+  height: min-content;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -8,26 +8,51 @@
 }
 
 .app header {
-  padding-left: 20px;
-  height: 35px;
-  background-color: lightgrey;
+  padding: 0 16px;
+  height: 40px;
+  background-color: var(--base02);
+  border-bottom: 1px solid var(--base01);
   display: flex;
   align-items: center;
+  gap: 16px;
+}
+
+.app header h3 {
+  margin: 0;
+  color: var(--base1);
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
 }
 
 .app header button {
-  margin-left: 50px;
+  padding: 3px 12px;
+  background: transparent;
+  border: 1px solid var(--base01);
+  border-radius: 4px;
+  color: var(--base0);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.app header button:hover {
+  border-color: var(--blue);
+  color: var(--blue);
+}
+
+.app header .settingsButton {
+  margin-left: auto;
 }
 
 .highlighted-code {
-  background-color: #f5f5d6;
+  background-color: rgba(181, 137, 0, 0.3);
 }
 
 .tokenPanel {
-  background-color: #fff;
+  background-color: var(--base03);
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  row-gap: 10px;
+  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  gap: 8px;
   padding: 15px;
   height: min-content;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import Editor from "@monaco-editor/react";
 import { useMemo } from "react";
-import { Position } from "./interpreter/token";
 import { lex } from "./interpreter/lexer";
 import SplitScreen from './components/SplitScreen';
 import ResultsPanel from './features/resultsPanel/ResultsPanel';
@@ -21,10 +20,6 @@ export default function App() {
 
   const tokens = useMemo(() => lex(input), [input]);
  
-  const cursorIsOverToken = ({ start, end }: Position, cursorPosition: number) => {
-    return cursorPosition >= start && cursorPosition <= end;
-  };
-
   function resetCodeHighlight() {
     highlightCode(0, 0);
   }
@@ -44,7 +39,7 @@ export default function App() {
               <div key={t.position.start} onMouseEnter={() => highlightCode(t.position.start, t.position.end)}>
                 <TokenCard
                   token={t}
-                  highlighted={cursorIsOverToken(t.position, cursorPosition)}
+                  highlighted={cursorPosition >= t.position.start && cursorPosition <= t.position.end}
                 />
               </div>
             ))}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import Editor from "@monaco-editor/react";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { lex } from "./interpreter/lexer";
 import SplitScreen from './components/SplitScreen';
 import ResultsPanel from './features/resultsPanel/ResultsPanel';
@@ -20,9 +20,7 @@ export default function App() {
 
   const tokens = useMemo(() => lex(input), [input]);
  
-  function resetCodeHighlight() {
-    highlightCode(0, 0);
-  }
+  const resetCodeHighlight = useCallback(() => highlightCode(0, 0), [highlightCode]);
 
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import ResultsPanel from './features/resultsPanel/ResultsPanel';
 import { useEditor } from './features/textEditor/useEditor';
 import TokenCard from "./features/resultsPanel/TokenCard";
 import ParserPanel from "./features/resultsPanel/ParserPanel";
-import styles from "./features/resultsPanel/ResultsPanel.module.css";
 import './App.css';
 
 export default function App() {
@@ -32,7 +31,7 @@ export default function App() {
       <SplitScreen>
         <Editor {...editorConfig} />
         <ResultsPanel>
-          <div className={styles.tokenPanel} onMouseLeave={resetCodeHighlight}>
+          <div className="tokenPanel" onMouseLeave={resetCodeHighlight}>
             {tokens.map(t => (
               <div key={t.position.start} onMouseEnter={() => highlightCode(t.position.start, t.position.end)}>
                 <TokenCard

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,7 @@ export default function App() {
         <ResultsPanel>
           <div className={styles.tokenPanel} onMouseLeave={resetCodeHighlight}>
             {tokens.map(t => (
-              <div onMouseEnter={() => highlightCode(t.position.start, t.position.end)}>
+              <div key={t.position.start} onMouseEnter={() => highlightCode(t.position.start, t.position.end)}>
                 <TokenCard
                   token={t}
                   highlighted={cursorIsOverToken(t.position, cursorPosition)}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ export default function App() {
   return (
     <div className="app">
       <header>
-        <h3>{document.title}</h3>
+        <h3>Parsenip</h3>
         <button onClick={resetInput}>New</button>
       </header>
       <SplitScreen>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import Editor from "@monaco-editor/react";
+import { useMemo } from "react";
 import { Position } from "./interpreter/token";
 import { lex } from "./interpreter/lexer";
 import SplitScreen from './components/SplitScreen';
@@ -18,7 +19,7 @@ export default function App() {
     config: editorConfig,
   } = useEditor();
 
-  const tokens = lex(input); // @TODO is this being called unnecessarily??
+  const tokens = useMemo(() => lex(input), [input]);
  
   const cursorIsOverToken = ({ start, end }: Position, cursorPosition: number) => {
     return cursorPosition >= start && cursorPosition <= end;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 import Editor from "@monaco-editor/react";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { lex } from "./interpreter/lexer";
 import SplitScreen from './components/SplitScreen';
 import ResultsPanel from './features/resultsPanel/ResultsPanel';
 import { useEditor } from './features/textEditor/useEditor';
 import TokenCard from "./features/resultsPanel/TokenCard";
 import ParserPanel from "./features/resultsPanel/ParserPanel";
+import SettingsPanel from './features/settings/SettingsPanel';
 import './App.css';
 
 export default function App() {
@@ -13,9 +14,25 @@ export default function App() {
     cursorPosition,
     input,
     resetInput,
+    settingsJson,
+    saveSettings,
+    resetSettings,
     highlightCode,
     config: editorConfig,
   } = useEditor();
+
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === ',' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setSettingsOpen(open => !open);
+      }
+    }
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, []);
 
   const tokens = useMemo(() => lex(input), [input]);
  
@@ -27,6 +44,7 @@ export default function App() {
       <header>
         <h3>Parsenip</h3>
         <button onClick={resetInput}>New</button>
+        <button className="settingsButton" onClick={() => setSettingsOpen(true)}>Settings</button>
       </header>
       <SplitScreen>
         <Editor {...editorConfig} />
@@ -52,6 +70,14 @@ export default function App() {
           />
         </ResultsPanel>
       </SplitScreen>
+      {settingsOpen && (
+        <SettingsPanel
+          settingsJson={settingsJson}
+          onSettingsChange={saveSettings}
+          onReset={resetSettings}
+          onClose={() => setSettingsOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/Expander.tsx
+++ b/src/components/Expander.tsx
@@ -1,25 +1,37 @@
 import { PropsWithChildren } from "react";
 import { colors } from "../features/resultsPanel/colors";
 
-type Props = PropsWithChildren<{ 
+type Props = PropsWithChildren<{
     title: string;
     expanded: boolean;
+    highlighted?: boolean;
     toggleExpanded: any; // TODO update with more specific type
 }>
 
-export default function Expander({ title, expanded, toggleExpanded, children }: Props) {
+export default function Expander({ title, expanded, highlighted, toggleExpanded, children }: Props) {
+    const chevron = expanded ? '▾' : '▸';
 
-    const indicator = { color: colors.green, symbol: "+" };
-
-    if (expanded) {
-        indicator.color = colors.red;
-        indicator.symbol = "-";
-    }
+    const chipStyle = {
+        display: 'inline-block',
+        backgroundColor: highlighted ? colors.gold : colors.blue,
+        color: '#fff',
+        fontSize: '0.68rem',
+        fontWeight: 700,
+        letterSpacing: '0.05em',
+        padding: '2px 6px',
+        borderRadius: '3px',
+        cursor: 'pointer',
+    };
 
     return (
         <div style={{ paddingLeft: '10px' }}>
-            <span style={{ color: indicator.color }}>{indicator.symbol} </span>
-            <span style={{ color: colors.blue }} onClick={toggleExpanded}>
+            <span
+                style={{ color: 'var(--base01)', marginRight: '5px', fontSize: '0.75rem', cursor: 'pointer' }}
+                onClick={toggleExpanded}
+            >
+                {chevron}
+            </span>
+            <span style={chipStyle} onClick={toggleExpanded}>
                 {title}
             </span>
             {expanded && children}

--- a/src/components/SplitScreen/SplitScreen.module.css
+++ b/src/components/SplitScreen/SplitScreen.module.css
@@ -7,6 +7,7 @@
 
 .divider {
     width: 3px;
+    background-color: var(--base02);
 
     &:hover {
         cursor: col-resize;

--- a/src/features/resultsPanel/ASTNode.tsx
+++ b/src/features/resultsPanel/ASTNode.tsx
@@ -70,24 +70,29 @@ export default function ASTNode(props: Props) {
     }
 
 
+    const isRoot = currNode.type === 'program';
+
     const styles = {
         paddingLeft: '10px',
-        marginBottom: '0px',
-        backgroundColor: highlighted ? '#f5f5d6': '',
+        borderLeft: isRoot ? 'none' : '1px solid var(--base01)',
+        marginLeft: isRoot ? '0' : '4px',
+        marginTop: '4px',
+        backgroundColor: highlighted ? 'rgba(181, 137, 0, 0.15)' : '',
     };
 
     return (
         <div style={styles} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
             <Expander
-                title={currNode.type} 
+                title={currNode.type}
                 expanded={expanded}
+                highlighted={highlighted}
                 toggleExpanded={toggleExpanded}
             >
                 {Object.entries(currNode).map(([key, value]) => {
                     return (
-                        <div key={key}>
-                            <span style={{ color: colors.gold }}>{key}: </span>
-                            <span style={{ color: colors.seafoam }}>
+                        <div key={key} style={{ marginTop: '4px' }}>
+                            <span style={{ color: colors.gold, fontSize: '0.8rem' }}>{key}: </span>
+                            <span style={{ color: colors.seafoam, fontFamily: 'monospace', fontSize: '0.82rem' }}>
                             {
                                 isASTNode(value)
                                     ? Array.isArray(value)

--- a/src/features/resultsPanel/ResultsPanel.module.css
+++ b/src/features/resultsPanel/ResultsPanel.module.css
@@ -1,24 +1,45 @@
 .tabs {
     display: flex;
-    height: 50px;
-    background-color: white;
-    padding-left: 5px;
+    align-items: center;
+    height: 44px;
+    background-color: var(--base02);
+    border-bottom: 1px solid var(--base01);
+    padding: 0 10px;
+}
+
+.tabGroup {
+    display: flex;
+    background-color: var(--base03);
+    border-radius: 6px;
+    padding: 3px;
+    gap: 2px;
 }
 
 .tab {
-    width: 100px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    padding: 4px 14px;
+    border-radius: 4px;
     cursor: pointer;
-    color: gray;
+    color: var(--base01);
+    font-size: 0.8rem;
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    transition: color 0.15s;
+    user-select: none;
+}
+
+.tab:hover {
+    color: var(--base0);
 }
 
 .activeTab {
-    border-bottom: 3px solid #4666ff;
-    color: black;
+    background-color: var(--base02);
+    color: var(--blue);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
 }
 
 .parserErrors {
-    background-color: #f09999;
+    background-color: rgba(220, 50, 47, 0.1);
+    border-left: 3px solid var(--red);
+    padding: 8px 16px;
+    color: var(--red);
 }

--- a/src/features/resultsPanel/ResultsPanel.module.css
+++ b/src/features/resultsPanel/ResultsPanel.module.css
@@ -19,15 +19,6 @@
     color: black;
 }
 
-.tokenPanel {
-    background-color: #fff;
-    display: grid;
-    grid-template-columns: repeat(6, 1fr);
-    row-gap: 10px;
-    padding: 15px;
-    height: min-content;
-}
-
 .parserErrors {
     background-color: #f09999;
 }

--- a/src/features/resultsPanel/ResultsPanel.tsx
+++ b/src/features/resultsPanel/ResultsPanel.tsx
@@ -35,20 +35,22 @@ export default function ResultsPanel({
     return (
         <div>
             <div className={styles.tabs}>
-                {tabs.map(t =>
-                    <div
-                        className={conditionalStyles({
-                            baseStyles: [styles.tab],
-                            conditionalStyles: [{
-                                condition: t.name === activeTab,
-                                styles: styles.activeTab
-                            }]
-                        })}
-                        onClick={() => setActiveTab(t.name)}
-                    >
-                        {t.name.charAt(0).toUpperCase() + t.name.slice(1)}
-                    </div>
-                )}
+                <div className={styles.tabGroup}>
+                    {tabs.map(t =>
+                        <div
+                            className={conditionalStyles({
+                                baseStyles: [styles.tab],
+                                conditionalStyles: [{
+                                    condition: t.name === activeTab,
+                                    styles: styles.activeTab
+                                }]
+                            })}
+                            onClick={() => setActiveTab(t.name)}
+                        >
+                            {t.name.charAt(0).toUpperCase() + t.name.slice(1)}
+                        </div>
+                    )}
+                </div>
             </div>
 
             <ActivePanel />

--- a/src/features/resultsPanel/TokenCard.tsx
+++ b/src/features/resultsPanel/TokenCard.tsx
@@ -9,49 +9,41 @@ interface Props {
 export default function TokenCard({ token, highlighted }: Props) {
     const { type, literal } = token;
 
-    const tokenColor =
-        type === TokenType.ILLEGAL
-        ? colors.red
-        : colors.blue
-    ;
-
     const isIllegal = type === TokenType.ILLEGAL;
+    const chipColor = isIllegal ? colors.red : highlighted ? colors.gold : colors.blue;
 
-    const styles = {
-        border: '1px solid',
+    const cardStyle = {
+        backgroundColor: highlighted ? 'rgba(181, 137, 0, 0.15)' : 'var(--base02)',
+        border: `1px solid ${highlighted ? 'var(--yellow)' : 'var(--base01)'}`,
+        borderRadius: '4px',
+        padding: '8px 10px',
         display: 'flex',
-        flexDirection: 'column' as 'column',
-        justifyContent: 'center',
-        alignItems: 'center',
-        width: 'auto',
-        borderColor: tokenColor,
-        color: tokenColor,
-        backgroundColor: highlighted ? '#f5f5d6' : '',
+        flexDirection: 'column' as const,
+        gap: '6px',
     };
 
-    const keyColor = isIllegal ? colors.red : colors.gold;
-    const valueColor = isIllegal ? colors.red: colors.seafoam;
+    const chipStyle = {
+        display: 'inline-block',
+        backgroundColor: chipColor,
+        color: '#fff',
+        fontSize: '0.68rem',
+        fontWeight: 700,
+        letterSpacing: '0.05em',
+        padding: '2px 6px',
+        borderRadius: '3px',
+        alignSelf: 'flex-start' as const,
+    };
+
+    const literalStyle = {
+        fontFamily: 'monospace',
+        fontSize: '0.85rem',
+        color: 'var(--base1)',
+    };
 
     return (
-        <div style={styles}>
-            <div>
-                <span style={{ color: keyColor }}>type: </span>
-                <span style={{ color: valueColor }}>{type}</span>
-            </div>
-            <div>
-                <span style={{ color: keyColor }}>value: </span>
-                <span style={{ color: valueColor }}>{literal}</span>
-            </div>
-
-            {/*<div>
-                <span style={{ color: keyColor }}>start: </span>
-                <span style={{ color: valueColor }}>{position.start}</span>
-            </div>
-
-            <div>
-                <span style={{ color: keyColor }}>end: </span>
-                <span style={{ color: valueColor }}>{position.end}</span>
-            </div>*/}
+        <div style={cardStyle}>
+            <span style={chipStyle}>{type}</span>
+            <span style={literalStyle}>{literal}</span>
         </div>
     );
 }

--- a/src/features/resultsPanel/colors.ts
+++ b/src/features/resultsPanel/colors.ts
@@ -2,6 +2,6 @@ export const colors = {
     blue: '#268bd2',
     seafoam: '#2aa198',
     gold: '#b58900',
-    green: 'green',
-    red: 'red',
+    green: '#859900',
+    red: '#dc322f',
 };

--- a/src/features/settings/SettingsPanel.module.css
+++ b/src/features/settings/SettingsPanel.module.css
@@ -1,0 +1,174 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.panel {
+  width: 520px;
+  max-height: 600px;
+  background: var(--base02);
+  border: 1px solid var(--base01);
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.header {
+  height: 41px;
+  padding: 0 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--base01);
+  color: var(--base1);
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+}
+
+.actions button {
+  background: transparent;
+  border: 1px solid var(--base01);
+  color: var(--base0);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.actions button:hover {
+  border-color: var(--base1);
+  color: var(--base1);
+}
+
+/* Scrollable form body */
+.content {
+  overflow-y: auto;
+  padding: 8px 0;
+  flex: 1;
+}
+
+/* Section */
+.section {
+  padding: 12px 0 8px;
+  border-bottom: 1px solid var(--base01);
+}
+
+.section:last-child {
+  border-bottom: none;
+}
+
+.sectionTitle {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--base01);
+  padding: 0 16px 6px;
+}
+
+/* Row */
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 16px;
+}
+
+.label {
+  font-size: 0.85rem;
+  color: var(--base0);
+}
+
+/* Toggle */
+.toggle {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  border-radius: 10px;
+  background: var(--base01);
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  transition: background 0.15s;
+}
+
+.toggleOn {
+  background: var(--blue);
+}
+
+.toggleKnob {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: white;
+  transition: transform 0.15s;
+}
+
+.toggleOn .toggleKnob {
+  transform: translateX(16px);
+}
+
+/* Number input */
+.numberInput {
+  width: 64px;
+  background: var(--base03);
+  border: 1px solid var(--base01);
+  color: var(--base0);
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.85rem;
+  font-family: inherit;
+}
+
+.numberInput:focus {
+  outline: none;
+  border-color: var(--blue);
+}
+
+/* Text input */
+.textInput {
+  width: 180px;
+  background: var(--base03);
+  border: 1px solid var(--base01);
+  color: var(--base0);
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.85rem;
+  font-family: inherit;
+}
+
+.textInput:focus {
+  outline: none;
+  border-color: var(--blue);
+}
+
+/* Select input */
+.selectInput {
+  background: var(--base03);
+  border: 1px solid var(--base01);
+  color: var(--base0);
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.85rem;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.selectInput:focus {
+  outline: none;
+  border-color: var(--blue);
+}

--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -1,0 +1,259 @@
+import { useEffect, useMemo } from "react";
+import styles from "./SettingsPanel.module.css";
+
+// ---------------------------------------------------------------------------
+// Settings schema
+// ---------------------------------------------------------------------------
+
+type BooleanDef = { key: string; label: string; type: "boolean"; default: boolean };
+type NumberDef  = { key: string; label: string; type: "number";  default: number;  min: number; max: number; step?: number };
+type SelectDef  = { key: string; label: string; type: "select";  default: string;  options: string[] };
+type TextDef    = { key: string; label: string; type: "text";    default: string };
+type SettingDef = BooleanDef | NumberDef | SelectDef | TextDef;
+
+type Section = { title: string; settings: SettingDef[] };
+
+const SECTIONS: Section[] = [
+  {
+    title: "Font",
+    settings: [
+      { key: "fontSize",      label: "Font Size",       type: "number",  default: 14,         min: 8,  max: 30, step: 1 },
+      { key: "fontFamily",    label: "Font Family",     type: "text",    default: "Menlo, Monaco, 'Courier New', monospace" },
+      { key: "fontLigatures", label: "Font Ligatures",  type: "boolean", default: false },
+      { key: "lineHeight",    label: "Line Height",     type: "number",  default: 0,          min: 0,  max: 60, step: 1 },
+    ],
+  },
+  {
+    title: "Cursor",
+    settings: [
+      { key: "cursorStyle",    label: "Cursor Style",    type: "select", default: "line",  options: ["line", "block", "underline", "line-thin", "block-outline", "underline-thin"] },
+      { key: "cursorBlinking", label: "Cursor Blinking", type: "select", default: "blink", options: ["blink", "smooth", "phase", "expand", "solid"] },
+    ],
+  },
+  {
+    title: "Editing",
+    settings: [
+      { key: "tabSize",              label: "Tab Size",               type: "number",  default: 2,                    min: 1, max: 8, step: 1 },
+      { key: "insertSpaces",         label: "Insert Spaces",          type: "boolean", default: true },
+      { key: "wordWrap",             label: "Word Wrap",              type: "select",  default: "off",                options: ["off", "on", "wordWrapColumn", "bounded"] },
+      { key: "formatOnPaste",        label: "Format On Paste",        type: "boolean", default: false },
+      { key: "formatOnType",         label: "Format On Type",         type: "boolean", default: false },
+      { key: "autoClosingBrackets",  label: "Auto Closing Brackets",  type: "select",  default: "languageDefined",    options: ["always", "languageDefined", "beforeWhitespace", "never"] },
+      { key: "autoClosingQuotes",    label: "Auto Closing Quotes",    type: "select",  default: "languageDefined",    options: ["always", "languageDefined", "beforeWhitespace", "never"] },
+    ],
+  },
+  {
+    title: "Display",
+    settings: [
+      { key: "lineNumbers",                   label: "Line Numbers",                  type: "select",  default: "on",   options: ["on", "off", "relative", "interval"] },
+      { key: "renderWhitespace",              label: "Render Whitespace",             type: "select",  default: "none", options: ["none", "boundary", "selection", "trailing", "all"] },
+      { key: "renderLineHighlight",           label: "Render Line Highlight",         type: "select",  default: "line", options: ["none", "gutter", "line", "all"] },
+      { key: "minimap.enabled",               label: "Minimap",                       type: "boolean", default: false },
+      { key: "folding",                       label: "Folding",                       type: "boolean", default: true },
+      { key: "bracketPairColorization.enabled", label: "Bracket Pair Colorization",  type: "boolean", default: true },
+    ],
+  },
+  {
+    title: "Scrolling",
+    settings: [
+      { key: "scrollBeyondLastLine", label: "Scroll Beyond Last Line", type: "boolean", default: false },
+      { key: "smoothScrolling",      label: "Smooth Scrolling",        type: "boolean", default: false },
+      { key: "mouseWheelZoom",       label: "Mouse Wheel Zoom",        type: "boolean", default: false },
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Dot-notation helpers
+// ---------------------------------------------------------------------------
+
+function getSettingValue(obj: Record<string, unknown>, key: string): unknown {
+  const parts = key.split(".");
+  let cur: unknown = obj;
+  for (const part of parts) {
+    if (cur == null || typeof cur !== "object") return undefined;
+    cur = (cur as Record<string, unknown>)[part];
+  }
+  return cur;
+}
+
+function setSettingValue(obj: Record<string, unknown>, key: string, value: unknown): Record<string, unknown> {
+  const parts = key.split(".");
+  const result = { ...obj };
+  let cur: Record<string, unknown> = result;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i];
+    cur[part] = typeof cur[part] === "object" && cur[part] !== null ? { ...(cur[part] as Record<string, unknown>) } : {};
+    cur = cur[part] as Record<string, unknown>;
+  }
+  cur[parts[parts.length - 1]] = value;
+  return result;
+}
+
+function buildDefaults(): Record<string, unknown> {
+  let obj: Record<string, unknown> = {};
+  for (const section of SECTIONS) {
+    for (const def of section.settings) {
+      obj = setSettingValue(obj, def.key, def.default);
+    }
+  }
+  return obj;
+}
+
+// ---------------------------------------------------------------------------
+// Control components
+// ---------------------------------------------------------------------------
+
+function Toggle({ checked, onChange }: { checked: boolean; onChange: (v: boolean) => void }) {
+  return (
+    <button
+      role="switch"
+      aria-checked={checked}
+      className={`${styles.toggle} ${checked ? styles.toggleOn : ""}`}
+      onClick={() => onChange(!checked)}
+    >
+      <span className={styles.toggleKnob} />
+    </button>
+  );
+}
+
+function NumberInput({ value, min, max, step, onChange }: { value: number; min: number; max: number; step?: number; onChange: (v: number) => void }) {
+  return (
+    <input
+      type="number"
+      className={styles.numberInput}
+      value={value}
+      min={min}
+      max={max}
+      step={step ?? 1}
+      onChange={e => onChange(Number(e.target.value))}
+    />
+  );
+}
+
+function TextInput({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <input
+      type="text"
+      className={styles.textInput}
+      value={value}
+      onChange={e => onChange(e.target.value)}
+    />
+  );
+}
+
+function SelectInput({ value, options, onChange }: { value: string; options: string[]; onChange: (v: string) => void }) {
+  return (
+    <select
+      className={styles.selectInput}
+      value={value}
+      onChange={e => onChange(e.target.value)}
+    >
+      {options.map(o => <option key={o} value={o}>{o}</option>)}
+    </select>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SettingRow
+// ---------------------------------------------------------------------------
+
+function SettingRow({ def, settings, onChange }: {
+  def: SettingDef;
+  settings: Record<string, unknown>;
+  onChange: (key: string, value: unknown) => void;
+}) {
+  const raw = getSettingValue(settings, def.key);
+
+  let control: React.ReactNode;
+  if (def.type === "boolean") {
+    const checked = raw != null ? Boolean(raw) : def.default;
+    control = <Toggle checked={checked} onChange={v => onChange(def.key, v)} />;
+  } else if (def.type === "number") {
+    const num = raw != null ? Number(raw) : def.default;
+    control = <NumberInput value={num} min={def.min} max={def.max} step={def.step} onChange={v => onChange(def.key, v)} />;
+  } else if (def.type === "text") {
+    const str = raw != null ? String(raw) : def.default;
+    control = <TextInput value={str} onChange={v => onChange(def.key, v)} />;
+  } else {
+    const str = raw != null ? String(raw) : def.default;
+    control = <SelectInput value={str} options={def.options} onChange={v => onChange(def.key, v)} />;
+  }
+
+  return (
+    <div className={styles.row}>
+      <span className={styles.label}>{def.label}</span>
+      {control}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section
+// ---------------------------------------------------------------------------
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className={styles.section}>
+      <div className={styles.sectionTitle}>{title}</div>
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SettingsPanel
+// ---------------------------------------------------------------------------
+
+interface Props {
+  settingsJson: string;
+  onSettingsChange: (json: string) => void;
+  onReset: () => void;
+  onClose: () => void;
+}
+
+export default function SettingsPanel({ settingsJson, onSettingsChange, onReset, onClose }: Props) {
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  const settings = useMemo<Record<string, unknown>>(() => {
+    try {
+      return JSON.parse(settingsJson) as Record<string, unknown>;
+    } catch {
+      return buildDefaults();
+    }
+  }, [settingsJson]);
+
+  function handleChange(key: string, value: unknown) {
+    const next = setSettingValue(settings, key, value);
+    onSettingsChange(JSON.stringify(next, null, 2));
+  }
+
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div className={styles.panel} onClick={e => e.stopPropagation()}>
+        <div className={styles.header}>
+          <span>Editor Settings</span>
+          <div className={styles.actions}>
+            <button onClick={onReset}>Reset</button>
+            <button onClick={onClose}>✕</button>
+          </div>
+        </div>
+        <div className={styles.content}>
+          {SECTIONS.map(section => (
+            <Section key={section.title} title={section.title}>
+              {section.settings.map(def => (
+                <SettingRow key={def.key} def={def} settings={settings} onChange={handleChange} />
+              ))}
+            </Section>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/textEditor/useEditor.tsx
+++ b/src/features/textEditor/useEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { editor as monaco, Range, IPosition } from "monaco-editor";
 import { EditorProps } from "@monaco-editor/react";
   
@@ -27,7 +27,7 @@ export function useEditor() {
   });
 
   
-  function updateDecorations(start: number, end: number) {
+  const updateDecorations = useCallback((start: number, end: number) => {
     const textModel = editor?.getModel();
 
     if (textModel) {
@@ -43,7 +43,7 @@ export function useEditor() {
         }
       ]);
     }
-  }
+  }, [editor]);
   
   function handleEditorMount(editor: monaco.IStandaloneCodeEditor) {
     setEditor(editor);

--- a/src/features/textEditor/useEditor.tsx
+++ b/src/features/textEditor/useEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { editor as monaco, Range, IPosition } from "monaco-editor";
 import { EditorProps } from "@monaco-editor/react";
   
@@ -6,7 +6,8 @@ export function useEditor() {
   const [editor, setEditor] = useState<monaco.IStandaloneCodeEditor>();
   const [cursorPosition, setCursorPosition] = useState(0);
   const decorationsCollectionRef = useRef<monaco.IEditorDecorationsCollection>();
-  const  { input, setInput, resetInput } = useEditorInput();
+  const { input, setInput, resetInput } = useEditorInput();
+  const { settingsJson, saveSettings, resetSettings, parsedSettings } = useEditorSettings();
   
   useEffect(() => {
     decorationsCollectionRef.current = editor?.createDecorationsCollection([
@@ -56,7 +57,7 @@ export function useEditor() {
   const config: EditorProps = {
     height: '100vh',
     width: '100%',
-    theme: 'vs-light',
+    theme: 'vs-dark',
     language: 'javascript',
     value: input,
     options: {
@@ -67,26 +68,55 @@ export function useEditor() {
       overviewRulerLanes: 0,
       scrollbar: {
         //@TODO: For some reason, this setting breaks code highlighting..investigate why
-        //vertical: 'hidden' 
-      }
+        //vertical: 'hidden'
+      },
+      ...(parsedSettings ?? {}),
     },
     onMount: handleEditorMount,
     onChange: handleChange,
-};
+  };
 
   return {
     handleEditorMount,
     handleChange,
 
     cursorPosition,
-    
+
     input,
     resetInput,
+
+    settingsJson,
+    saveSettings,
+    resetSettings,
 
     highlightCode: updateDecorations,
     config,
   };
 
+}
+
+
+function useEditorSettings() {
+  const [settingsJson, setSettingsJson] = useState(
+    () => localStorage.getItem('editorSettings') ?? '{}'
+  );
+
+  const parsedSettings = useMemo(() => {
+    try { return JSON.parse(settingsJson); }
+    catch { return null; }
+  }, [settingsJson]);
+
+  function saveSettings(json: string) {
+    localStorage.setItem('editorSettings', json);
+    setSettingsJson(json);
+  }
+
+  function resetSettings() {
+    localStorage.removeItem('editorSettings');
+    setSettingsJson('{}');
+  }
+
+  return { settingsJson, saveSettings, resetSettings, parsedSettings };
 }
 
 

--- a/src/index.css
+++ b/src/index.css
@@ -8,8 +8,20 @@
   -moz-osx-font-smoothing: grayscale;
   -webkit-text-size-adjust: 100%;
 
+  /* Dark neutral surfaces */
+  --base03: #1a1a1a;
+  --base02: #252525;
+  --base01: #4a4a4a;
+  --base0: #839496;
+  --base1: #93a1a1;
+  --yellow: #b58900;
+  --red: #dc322f;
   --blue: #268bd2;
-  --highlight-yellow: #ffffeo;
+  --cyan: #2aa198;
+  --green: #859900;
+
+  color: var(--base0);
+  background-color: var(--base03);
 }
 
 a {


### PR DESCRIPTION
## Summary
- Replace hardcoded colors with CSS custom properties (Solarized-inspired dark palette)
- Redesign header, tab bar, token cards, AST nodes, and expander for dark theme
- Add `useEditorSettings` hook with localStorage persistence; parsed settings spread into Monaco config
- Wire `SettingsPanel` into `App` with Cmd+, keyboard shortcut and Reset support

## Test plan
- [ ] App loads with dark theme applied throughout
- [ ] Settings panel opens with Cmd+, and closes with Escape or ✕
- [ ] Changing a setting (e.g. font size) updates the editor immediately
- [ ] Settings persist across page reloads
- [ ] Reset button restores defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)